### PR TITLE
fix(security): block file extension probes and dotfile access

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,7 +137,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.21.1)
       msgpack (~> 1.2)
-    brakeman (8.0.2)
+    brakeman (8.0.4)
       racc
     builder (3.3.0)
     capybara (3.40.0)
@@ -642,7 +642,7 @@ CHECKSUMS
   bigdecimal (4.0.1) sha256=8b07d3d065a9f921c80ceaea7c9d4ae596697295b584c296fe599dd0ad01c4a7
   bindex (0.8.1) sha256=7b1ecc9dc539ed8bccfc8cb4d2732046227b09d6f37582ff12e50a5047ceb17e
   bootsnap (1.21.1) sha256=9373acfe732da35846623c337d3481af8ce77c7b3a927fb50e9aa92b46dbc4c4
-  brakeman (8.0.2) sha256=7b02065ce8b1de93949cefd3f2ad78e8eb370e644b95c8556a32a912a782426a
+  brakeman (8.0.4) sha256=7bf921fa9638544835df9aa7b3e720a9a72c0267f34f92135955edd80d4dcf6f
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   capybara (3.40.0) sha256=42dba720578ea1ca65fd7a41d163dd368502c191804558f6e0f71b391054aeef
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,7 @@ Rails.application.routes.draw do
     # Redirect /community paths that may linger from old links or crawlers
     get "community", to: redirect("/", status: 301)
     get "community/:id", to: redirect("/%{id}", status: 301), constraints: { id: /[^\/]+/ }
-    get ":id", to: "users#show", as: :rubycommunity_user, constraints: { id: /[^\/]+/ }
+    get ":id", to: "users#show", as: :rubycommunity_user, constraints: { id: /[^\/\.]+/ }
   end
 
   # Add sign out route for OmniAuth-only authentication
@@ -104,10 +104,11 @@ Rails.application.routes.draw do
   get "legal", to: "legal#show", defaults: { page: "legal_notice" }, as: :legal_notice
 
   # Category routes (must be at the end due to catch-all nature)
-  get ":id", to: "categories#show", as: :category, constraints: { id: /[^\/]+/ }
+  # Exclude paths with dots so file requests (sitemap.xml, robots.txt) fall through to public/
+  get ":id", to: "categories#show", as: :category, constraints: { id: /[^\/\.]+/ }
 
   # Post routes (must be after category)
-  get ":category_id/:id", to: "posts#show", as: :post, constraints: { category_id: /[^\/]+/, id: /[^\/]+/ }
+  get ":category_id/:id", to: "posts#show", as: :post, constraints: { category_id: /[^\/\.]+/, id: /[^\/\.]+/ }
   get ":category_id/:id/og-image.webp", to: "posts#image", as: :post_image, constraints: { category_id: /[^\/]+/, id: /[^\/]+/ }
 
   # Defines the root path route ("/")

--- a/lib/middleware/malicious_path_blocker.rb
+++ b/lib/middleware/malicious_path_blocker.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 
 module Middleware
-  # Blocks known malicious request paths (WordPress exploits, PHP files, etc.)
-  # before they reach the Rails router. Runs early in the middleware stack
-  # for efficiency.
+  # Blocks known malicious request paths before they reach the Rails router.
+  # Two strategies:
+  # 1. Blocklist: known exploit patterns (WordPress, PHP, etc.)
+  # 2. File extension guard: any path with a file extension that doesn't
+  #    correspond to an actual file in public/ gets blocked. This prevents
+  #    scanners from probing paths like /delete.sql, /secrets.txt, etc.
   class MaliciousPathBlocker
     BLOCKED_PATTERNS = [
       # WordPress
@@ -16,11 +19,17 @@ module Middleware
       /phpinfo/i, /phpmyadmin/i,
       /admin\.php/i, /setup\.php/i,
       # Path traversal
-      /\.\.\//
+      /\.\.\//,
+      # Dotfiles (e.g. .rbenv-vars, .yarnrc, .dockerignore)
+      /\/\.[^\/]+$/
     ].freeze
+
+    # Matches paths like /foo.xml, /bar.txt, /Dockerfile (no extension but known probe)
+    FILE_EXTENSION_PATTERN = /\.[a-zA-Z0-9]+$/
 
     def initialize(app)
       @app = app
+      @public_path = Rails.public_path
     end
 
     def call(env)
@@ -29,6 +38,9 @@ module Middleware
       if blocked_path?(path)
         log_blocked_request(env, path)
         [ 403, { "Content-Type" => "text/plain" }, [ "Forbidden" ] ]
+      elsif unknown_file_request?(path)
+        log_blocked_request(env, path)
+        [ 404, { "Content-Type" => "text/plain" }, [ "Not Found" ] ]
       else
         @app.call(env)
       end
@@ -38,6 +50,13 @@ module Middleware
 
     def blocked_path?(path)
       BLOCKED_PATTERNS.any? { |pattern| path.match?(pattern) }
+    end
+
+    def unknown_file_request?(path)
+      return false unless path.match?(FILE_EXTENSION_PATTERN)
+
+      # Allow if a real file exists in public/
+      !File.exist?(File.join(@public_path, path))
     end
 
     def log_blocked_request(env, path)

--- a/test/middleware/malicious_path_blocker_test.rb
+++ b/test/middleware/malicious_path_blocker_test.rb
@@ -47,9 +47,52 @@ class MaliciousPathBlockerTest < ActionDispatch::IntegrationTest
     assert_response :forbidden
   end
 
+  # Dotfiles (scanner probes)
+  test "blocks dotfile requests like .rbenv-vars" do
+    get "/.rbenv-vars"
+    assert_response :forbidden
+  end
+
+  test "blocks dotfile requests like .yarnrc" do
+    get "/.yarnrc"
+    assert_response :forbidden
+  end
+
+  # File extension probes (not in public/)
+  test "blocks unknown file extensions like delete.sql" do
+    get "/delete.sql"
+    assert_response :not_found
+  end
+
+  test "blocks unknown file extensions like secrets.txt" do
+    get "/secrets.txt"
+    assert_response :not_found
+  end
+
+  test "blocks unknown file extensions like remove.sh" do
+    get "/remove.sh"
+    assert_response :not_found
+  end
+
+  test "blocks unknown file extensions like sitemap.xml" do
+    get "/sitemap.xml"
+    assert_response :not_found
+  end
+
   # Apple touch icon — legitimate iOS request, served as static file
   test "allows apple-touch-icon-precomposed requests" do
     get "/apple-touch-icon-precomposed.png"
+    assert_response :success
+  end
+
+  # Known public files should pass through
+  test "allows robots.txt" do
+    get "/robots.txt"
+    assert_response :success
+  end
+
+  test "allows favicon.ico" do
+    get "/favicon.ico"
     assert_response :success
   end
 


### PR DESCRIPTION
## Summary
- Enhance `MaliciousPathBlocker` middleware to block requests for file extensions (`.sql`, `.txt`, `.sh`, etc.) when no matching file exists in `public/`
- Block dotfile requests (`.rbenv-vars`, `.yarnrc`, `.dockerignore`, etc.) as known scanner probes
- Tighten catch-all route constraints to exclude paths with dots, so static file requests fall through to `public/` properly

## Test plan
- [x] All 124 tests pass
- [x] RuboCop clean
- [x] Brakeman 0 warnings
- [x] New tests for dotfile blocking, unknown file extension blocking, and known public file passthrough (`robots.txt`, `favicon.ico`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)