### PR TITLE
Add auto-merge for Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,25 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Enable auto-merge for patch and minor updates
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that automatically enables squash-merge for Dependabot patch and minor dependency updates
- Major version updates are skipped and require manual review
- Auto-merge waits for all required status checks (scan_js, scan_ruby, lint, test) to pass before merging

## Test plan
- [ ] Verify workflow triggers on next Dependabot PR
- [ ] Confirm patch/minor updates get auto-merged after CI passes
- [ ] Confirm major updates are left open for manual review

🤖 Generated with [Claude Code](https://claude.com/claude-code)