### PR TITLE
fix(github-sync): retry transient network errors during GraphQL batch

### DIFF
--- a/app/models/concerns/user/github_syncable.rb
+++ b/app/models/concerns/user/github_syncable.rb
@@ -1,10 +1,25 @@
 require "net/http"
 require "json"
+require "openssl"
+require "socket"
 
 module User::GithubSyncable
   extend ActiveSupport::Concern
 
   GITHUB_GRAPHQL_ENDPOINT = "https://api.github.com/graphql"
+
+  TRANSIENT_NETWORK_ERRORS = [
+    Net::OpenTimeout,
+    Net::ReadTimeout,
+    Net::WriteTimeout,
+    EOFError,
+    IOError,
+    SocketError,
+    Errno::ECONNRESET,
+    Errno::ECONNREFUSED,
+    Errno::EPIPE,
+    OpenSSL::SSL::SSLError
+  ].freeze
 
   # Sync from OAuth callback data
   def sync_github_data_from_oauth!(auth_data)
@@ -155,12 +170,12 @@ module User::GithubSyncable
           else
             return { errors: [ "HTTP #{response.code}: #{response.message}" ] }
           end
-        rescue Net::OpenTimeout, Net::ReadTimeout => e
+        rescue *TRANSIENT_NETWORK_ERRORS => e
           if attempt < retries - 1
             sleep(2 ** (attempt + 1))
             next
           else
-            return { errors: [ "Request timed out: #{e.message}" ] }
+            return { errors: [ "Network error: #{e.class}: #{e.message}" ] }
           end
         end
       end

--- a/test/models/concerns/user/github_syncable_test.rb
+++ b/test/models/concerns/user/github_syncable_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "webmock/minitest"
+
+class User::GithubSyncableTest < ActiveSupport::TestCase
+  setup do
+    WebMock.disable_net_connect!(allow_localhost: true)
+    @user = users(:user_with_testimonial)
+    @user.update_columns(username: "octocat")
+  end
+
+  teardown do
+    WebMock.reset!
+    WebMock.allow_net_connect!
+  end
+
+  # Skip the exponential backoff so tests run fast.
+  setup { User.singleton_class.send(:define_method, :sleep) { |_| } }
+  teardown { User.singleton_class.send(:remove_method, :sleep) }
+
+  test "batch_sync_github_data! retries on EOFError and succeeds on second attempt" do
+    stub_request(:post, User::GithubSyncable::GITHUB_GRAPHQL_ENDPOINT)
+      .to_raise(EOFError.new("end of file reached"))
+      .then.to_return(
+        status: 200,
+        body: {
+          data: {
+            user_0: { login: "octocat", name: "The Octocat", email: nil, bio: nil, company: nil, websiteUrl: nil, twitterUsername: nil, location: nil, avatarUrl: "https://example.com/a.png" },
+            repos_0: { nodes: [] }
+          }
+        }.to_json
+      )
+
+    result = User.batch_sync_github_data!([ @user ], api_token: "token")
+
+    assert_equal 1, result[:updated], result[:errors].inspect
+    assert_equal 0, result[:failed]
+  end
+
+  test "batch_sync_github_data! returns a network error after exhausting retries" do
+    stub_request(:post, User::GithubSyncable::GITHUB_GRAPHQL_ENDPOINT)
+      .to_raise(EOFError.new("end of file reached"))
+
+    result = User.batch_sync_github_data!([ @user ], api_token: "token")
+
+    assert_equal 0, result[:updated]
+    assert_equal 1, result[:failed]
+    assert_match(/EOFError/, result[:errors].first.to_s)
+  end
+end


### PR DESCRIPTION
## Summary

Fixes a production `EOFError: end of file reached` raised from `UpdateGithubDataJob` → `User::GithubSyncable#github_graphql_request`.

## Root cause

GitHub's GraphQL endpoint occasionally closes connections mid-response, surfacing in Ruby as `EOFError` (and siblings like `Errno::ECONNRESET`, `OpenSSL::SSL::SSLError`). The retry loop in `github_graphql_request` only rescued `Net::OpenTimeout` / `Net::ReadTimeout`, so any connection reset escaped the rescue and failed the *entire* batch of users without retrying. The `UpdateGithubDataJob` would bail out partway through, leaving users un-synced.

## Fix

Extracted the set of transient network errors into a `TRANSIENT_NETWORK_ERRORS` constant and rescue them uniformly in the retry loop, so they trigger the existing backoff/retry (2 attempts, 2s sleep) just like timeouts already did. This matches the user's request: *don't* skip the error — make it work by actually retrying.

## Test plan

- [x] New `test/models/concerns/user/github_syncable_test.rb` with two cases:
  - `batch_sync_github_data!` retries on `EOFError` and succeeds on the second attempt
  - `batch_sync_github_data!` returns a network error after exhausting retries
- [x] Confirmed both reproduce the production error when reverted to the old rescue clause.
- [x] `rails test` — full suite (334 tests) passes.
- [x] `rubocop` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)